### PR TITLE
Use .env for sensitive information

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,11 +36,17 @@ php artisan vendor:publish --provider="Biscolab\ReCaptcha\ReCaptchaServiceProvid
 ## Configuration
 
 ### Add your API Keys
-Open `config/recaptcha.php` configuration file and set `api_site_key`, `api_secret_key` and `version`:
+Open `.env` file and set `RECAPTCHA_SITE_KEY` and `RECAPTCHA_SECRET_KEY`:
+```php
+RECAPTCHA_SITE_KEY=YOUR_API_SITE_KEY
+RECAPTCHA_SECRET_KEY=YOUR_API_SECRET_KEY
+```
+
+Open `config/recaptcha.php` configuration file and set `version`:
 ```php
 return [
-    'api_site_key'      => 'YOUR_API_SITE_KEY',
-    'api_secret_key'    => 'YOUR_API_SECRET_KEY',
+    'api_site_key'      => env('RECAPTCHA_SITE_KEY', ''),
+    'api_secret_key'    => env('RECAPTCHA_SECRET_KEY', ''),
     'version'           => 'v2' // supported: v2|invisible 
     'skip_ip'           => [] // array of IP addresses - String: dotted quad format e.g.: 127.0.0.1
 ];

--- a/config/recaptcha.php
+++ b/config/recaptcha.php
@@ -19,7 +19,7 @@ return [
      * get site key @ www.google.com/recaptcha/admin
      *
      */
-    'api_site_key'   => '',
+    'api_site_key'   => env('RECAPTCHA_SITE_KEY', ''),
 
     /**
      *
@@ -27,7 +27,7 @@ return [
      * get secret key @ www.google.com/recaptcha/admin
      *
      */
-    'api_secret_key' => '',
+    'api_secret_key' => env('RECAPTCHA_SECRET_KEY', ''),
 
     /**
      *


### PR DESCRIPTION
When we are talking about API keys, tokens, passwords, etc. **ALWAYS** use .env file, cause (by default) it is not included in VCS so that these variables won't be compromised.