### PR TITLE
added support for recaptcha.net via config

### DIFF
--- a/config/recaptcha.php
+++ b/config/recaptcha.php
@@ -41,6 +41,16 @@ return [
 
     /**
      *
+     * ReCATCHA Base URL
+     * Supported: "www.google.com", "www.recaptcha.net",
+     *
+     * get more info @ https://developers.google.com/recaptcha/docs/faq#can-i-use-recaptcha-globally
+     *
+     */
+    'baseurl' => 'www.google.com',
+
+    /**
+     *
      * The curl timout in seconds to validate a recaptcha token
      * @since v3.5.0
      *

--- a/config/recaptcha.php
+++ b/config/recaptcha.php
@@ -47,7 +47,7 @@ return [
      * get more info @ https://developers.google.com/recaptcha/docs/faq#can-i-use-recaptcha-globally
      *
      */
-    'baseurl' => 'www.google.com',
+    'baseurl' => env('RECAPTCHA_BASEURL', 'www.google.com'),
 
     /**
      *

--- a/src/ReCaptchaBuilder.php
+++ b/src/ReCaptchaBuilder.php
@@ -93,6 +93,7 @@ class ReCaptchaBuilder
         $this->setApiSecretKey($api_secret_key);
         $this->setVersion($version);
         $this->setSkipByIp($this->skipByIp());
+        $this->setAPIURL();
     }
 
     /**
@@ -166,6 +167,17 @@ class ReCaptchaBuilder
     }
 
     /**
+     *
+     * @return ReCaptchaBuilder
+     */
+    public function setAPIURL(): ReCaptchaBuilder
+    {
+        $this->api_url = 'https://'.config('recaptcha.baseurl','www.google.com').'/recaptcha/api/siteverify';
+
+        return $this;
+    }
+
+    /**
      * @return array|mixed
      */
     public function getIpWhitelist()
@@ -231,9 +243,11 @@ class ReCaptchaBuilder
             $html = $this->getOnLoadCallback();
         }
 
+        $baseURL = config('recaptcha.baseurl','www.google.com');
+
         // Create query string
         $query = ($query) ? '?' . http_build_query($query) : "";
-        $html .= "<script src=\"https://www.google.com/recaptcha/api.js" . $query . "\" async defer></script>";
+        $html .= "<script src=\"https://".$baseURL."/recaptcha/api.js" . $query . "\" async defer></script>";
 
         return $html;
     }

--- a/src/ReCaptchaBuilderV3.php
+++ b/src/ReCaptchaBuilderV3.php
@@ -46,7 +46,7 @@ class ReCaptchaBuilderV3 extends ReCaptchaBuilder
             return '';
         }
 
-        $html = "<script src=\"https://www.google.com/recaptcha/api.js?render={$this->api_site_key}\"></script>";
+        $html = "<script src=\"https://".config('recaptcha.baseurl','www.google.com')."/recaptcha/api.js?render={$this->api_site_key}\"></script>";
 
         $action = Arr::get($configuration, 'action', 'homepage');
 


### PR DESCRIPTION
allows use of www.recaptcha.net for countries that can't access the base www.google.com (see https://developers.google.com/recaptcha/docs/faq#can-i-use-recaptcha-globally)