### PR TITLE
Feature skip IP/CIDR netmask

### DIFF
--- a/config/recaptcha.php
+++ b/config/recaptcha.php
@@ -51,9 +51,10 @@ return [
     /**
      *
      * IP addresses for which validation will be skipped
+     * IP/CIDR netmask eg. 127.0.0.0/24, also 127.0.0.1 is accepted and /32 assumed
      *
      */
-    'skip_ip'                      => [],
+    'skip_ip'                      => env('RECAPTCHA_SKIP_IP', []),
 
     /**
      *

--- a/src/ReCaptchaBuilder.php
+++ b/src/ReCaptchaBuilder.php
@@ -12,6 +12,7 @@
 namespace Biscolab\ReCaptcha;
 
 use Illuminate\Support\Arr;
+use Symfony\Component\HttpFoundation\IpUtils;
 
 /**
  * Class ReCaptchaBuilder
@@ -247,8 +248,7 @@ class ReCaptchaBuilder
      */
     public function skipByIp(): bool
     {
-
-        return (in_array(request()->ip(), $this->getIpWhitelist()));
+        return IpUtils::checkIp(request()->ip(), $this->getIpWhitelist());
     }
 
     /**


### PR DESCRIPTION
Thanks for developing this package, it was really helpful to integrate reCAPTCHA.
I had to deal with some skip IP address subnet, so I wanted to make it configurable.

- add the config ENV param RECAPTCHA_SKIP_IP to sets skip IP with different env
- add support IP/[CIDR](https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing) mask for skip IP