### PR TITLE
Laravel 9 Support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,9 +8,15 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        php: ['7.3', '7.4', '8.0']
-        
-    name: PHP ${{ matrix.php }} Test on ${{ matrix.os }}
+        php: [ 7.3, 7.4, '8.0', 8.1 ]
+        laravel: [ 7, 8, 9 ]
+        exclude:
+          - php: 7.3
+            laravel: 9
+          - php: 7.4
+            laravel: 9
+
+    name: PHP ${{ matrix.php }} Test on ${{ matrix.os }} – Laravel ${{ matrix.laravel }}
 
     steps:
     - name: Checkout
@@ -19,8 +25,8 @@ jobs:
     - name: Setup PHP
       uses: shivammathur/setup-php@v2
       with:
-        php-version: ${{matrix.php}} 
- 
+        php-version: ${{matrix.php}}
+
     - name: Install dependencies
       uses: php-actions/composer@v5
       with:
@@ -29,4 +35,4 @@ jobs:
     - name: Run composer test script
       uses: php-actions/composer@v5
       with:
-        command: test 
+        command: test

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ matrix:
 before_install:
   - composer require "illuminate/routing:${ILLUMINATE_VERSION}" --no-update --prefer-dist
   - composer require "illuminate/support:${ILLUMINATE_VERSION}" --no-update --prefer-dist
-  - composer require "orchestra/testbench:${TESTBENCH_VERSION/5\./3\.}" --no-update --prefer-dist
+  - composer require "orchestra/testbench:${TESTBENCH_VERSION}" --no-update --prefer-dist
 
 install: travis_retry composer install --prefer-source --no-interaction
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,31 @@ language: php
 php:
   - 7.3
   - 7.4
+  - 8.0
+  - 8.1
 
-before_script:
-  - travis_retry composer self-update
-  - travis_retry composer install --prefer-source --no-interaction
+env:
+  - ILLUMINATE_VERSION=^7.0 TESTBENCH_VERSION=5.*
+  - ILLUMINATE_VERSION=^8.0 TESTBENCH_VERSION=6.*
+  - ILLUMINATE_VERSION=^9.0 TESTBENCH_VERSION=^7.0
+
+matrix:
+  exclude:
+    # Don't test Laravel 9 on PHP 7.3 or PHP 7.4, as the mininmum
+    # required PHP version for this Laravel version is 8.0.2
+    - php: 7.3
+      env: ILLUMINATE_VERSION=^9.0 TESTBENCH_VERSION=^7.0
+    - php: 7.4
+      env: ILLUMINATE_VERSION=^9.0 TESTBENCH_VERSION=^7.0
+
+before_install:
+  - composer require "illuminate/routing:${ILLUMINATE_VERSION}" --no-update --prefer-dist
+  - composer require "illuminate/support:${ILLUMINATE_VERSION}" --no-update --prefer-dist
+  - composer require "orchestra/testbench:${TESTBENCH_VERSION/5\./3\.}" --no-update --prefer-dist
+
+install: travis_retry composer install --prefer-source --no-interaction
+
+script:
+  - composer test
 
 fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,8 @@ php:
   - 7.3
   - 7.4
   - 8.0
-  - 8.1
+# PHP 8.1 isn't currently support by Travis CI
+#  - 8.1
 
 env:
   - ILLUMINATE_VERSION=^7.0 TESTBENCH_VERSION=5.*

--- a/README.md
+++ b/README.md
@@ -14,14 +14,14 @@ Available reCAPTCHA versions:
 
 ## System requirements
 
-| Package        | reCAPTCHA                     | PHP                   | Laravel                      | Docs                                                                   |
-| -------------- | ----------------------------- | --------------------- | ---------------------------- | ---------------------------------------------------------------------- |
-| 5.x            | v3, v2 Invisible, v2 Checkbox | 7.3 or greater        | 7, 8                         | [latest](https://laravel-recaptcha-docs.biscolab.com)                  |
-| 4.2.x to 4.4.x | v3, v2 Invisible, v2 Checkbox | 7.1 or greater        | 5.5 or greater, 6, 7, 8      | [v4.4.x](https://laravel-recaptcha-docs.biscolab.com/docs/4.4.x/intro) |
-| 4.1.x          | v3, v2 Invisible, v2 Checkbox | 7.1 or greater        | 5.5 or greater, 6, 7         | [v4.1.x](https://laravel-recaptcha-docs.biscolab.com/docs/4.1.x/intro) |
-| 4.0.x          | v3, v2 Invisible, v2 Checkbox | 7.1 or greater        | 5.5 or greater, 6            | [v4.0.x](https://laravel-recaptcha-docs.biscolab.com/docs/4.0.x/intro) |
-| 3.x            | v3, v2 Invisible, v2 Checkbox | 7.1 or greater        | 5.5 or greater, 6 ready (\*) | [v3.6.1](https://laravel-recaptcha-docs.biscolab.com/docs/3.6.1/intro) |
-| 2.x            | v2 Invisible, v2 Checkbox     | 5.5.9, 7.0 or greater | 5.0 or greater               | [v2.0.4](https://laravel-recaptcha-docs.biscolab.com/docs/2.0.4/intro) |
+| Package        | reCAPTCHA                     | PHP                   | Laravel                                  | Docs                                                                   |
+| -------------- | ----------------------------- | --------------------- |------------------------------------------| ---------------------------------------------------------------------- |
+| 5.x            | v3, v2 Invisible, v2 Checkbox | 7.3 or greater        | 7, 8 & 9 (requires PHP 8.0.2 or greater) | [latest](https://laravel-recaptcha-docs.biscolab.com)                  |
+| 4.2.x to 4.4.x | v3, v2 Invisible, v2 Checkbox | 7.1 or greater        | 5.5 or greater, 6, 7, 8                  | [v4.4.x](https://laravel-recaptcha-docs.biscolab.com/docs/4.4.x/intro) |
+| 4.1.x          | v3, v2 Invisible, v2 Checkbox | 7.1 or greater        | 5.5 or greater, 6, 7                     | [v4.1.x](https://laravel-recaptcha-docs.biscolab.com/docs/4.1.x/intro) |
+| 4.0.x          | v3, v2 Invisible, v2 Checkbox | 7.1 or greater        | 5.5 or greater, 6                        | [v4.0.x](https://laravel-recaptcha-docs.biscolab.com/docs/4.0.x/intro) |
+| 3.x            | v3, v2 Invisible, v2 Checkbox | 7.1 or greater        | 5.5 or greater, 6 ready (\*)             | [v3.6.1](https://laravel-recaptcha-docs.biscolab.com/docs/3.6.1/intro) |
+| 2.x            | v2 Invisible, v2 Checkbox     | 5.5.9, 7.0 or greater | 5.0 or greater                           | [v2.0.4](https://laravel-recaptcha-docs.biscolab.com/docs/2.0.4/intro) |
 
 > (\*) Latest version (3.6.1) is Laravel 6 ready
 

--- a/composer.json
+++ b/composer.json
@@ -20,11 +20,12 @@
         }
     ],
     "require": {
-        "php": "^7.3|^8.0",
-        "laravel/framework": "^7.0|^8.0"
+        "php": "^8.0.2",
+        "illuminate/routing": "^7.0|^8.0|^9.0",
+        "illuminate/support": "^7.0|^8.0|^9.0"
     },
     "require-dev": {
-        "orchestra/testbench": "5.*|6.*",
+        "orchestra/testbench": "5.*|6.*|^7.0",
         "phpunit/phpunit": "^9.1"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "^8.0.2",
+        "php": "^7.3|^8.0",
         "illuminate/routing": "^7.0|^8.0|^9.0",
         "illuminate/support": "^7.0|^8.0|^9.0"
     },


### PR DESCRIPTION
This PR adds support for Laravel 9.

It builds upon and improves the changes suggested in #71 by:
1. Updating the required dependency versions in `composer.json`
2. Removing the `laravel/framework` dependency in favour of `illuminate/support` and `illuminate/routing`
3. Updates `.travis.yml` to cater for Laravel 9 and the appropriate PHP version
4. Applies the same updates to Github Actions