### PR TITLE
Remove fallback error message from recaptcha validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,10 +126,6 @@ return [
     'explicit'                     => false, // true|false
     // @since v4.3.0
     'api_domain'                   => "www.google.com", // default value is "www.google.com"
-    // @since v5.1.0
-    'empty_message'                => false,
-    // @since v5.1.0
-    'error_message_key'            => 'validation.recaptcha',
     // @since v4.0.0
     'tag_attributes'               => [
         'theme'                    => 'light', // "light"|"dark"
@@ -154,8 +150,6 @@ return [
 | `default_form_id`                   | `string`                | the default form ID. Only for "invisible" reCAPTCHA                                                                                                                                                                                                              | `'biscolab-recaptcha-invisible-form'` |
 | `explicit`                          | `bool`                  | deferring the render can be achieved by specifying your onload callback function and adding parameters to the JavaScript resource. It has no effect with v3 and invisible (supported values: true&#124;false)                                                    | `false`                               |
 | `api_domain`                        | `string`                | customize API domain. Default value is `'www.google.com'`, but, if not accessible you ca set that value to `'www.recaptcha.net'`. More info about [Can I use reCAPTCHA globally?](https://developers.google.com/recaptcha/docs/faq#can-i-use-recaptcha-globally) | `'www.google.com'`                    |
-| `empty_message`                     | `bool`                  | set default error message to `null`                                                                                                                                                                                                                              | `false`                               |
-| `error_message_key`                 | `string`                | set default error message translation key                                                                                                                                                                                                                        | `'validation.recaptcha'`              |
 
 #### (array) tag_attributes
 

--- a/config/recaptcha.php
+++ b/config/recaptcha.php
@@ -114,24 +114,6 @@ return [
 
     /**
      *
-     * Set `true` when the error message must be null
-     * @since v5.1.0
-     * Default false
-     *
-     */
-    'empty_message' => false,
-
-    /**
-     *
-     * Set either the error message or the errom message translation key
-     * @since v5.1.0
-     * Default 'validation.recaptcha'
-     *
-     */
-    'error_message_key' => 'validation.recaptcha',
-
-    /**
-     *
      * g-recaptcha tag attributes and grecaptcha.render parameters (v2 only)
      * @see   https://developers.google.com/recaptcha/docs/display#render_param
      * @since v4.0.0

--- a/src/ReCaptchaServiceProvider.php
+++ b/src/ReCaptchaServiceProvider.php
@@ -47,15 +47,9 @@ class ReCaptchaServiceProvider extends ServiceProvider
      */
     public function addValidationRule()
     {
-        $message = null;
-
-        if (!config('recaptcha.empty_message')) {
-            $message = trans(config('recaptcha.error_message_key'));
-        }
         Validator::extendImplicit(recaptchaRuleName(), function ($attribute, $value) {
-
             return app('recaptcha')->validate($value);
-        }, $message);
+        });
     }
 
     /**

--- a/tests/RecaptchaCustomValidationRuleTest.php
+++ b/tests/RecaptchaCustomValidationRuleTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Biscolab\ReCaptcha\Tests;
+
+use Biscolab\ReCaptcha\Facades\ReCaptcha;
+use Biscolab\ReCaptcha\ReCaptchaBuilder;
+use Illuminate\Support\Facades\Lang;
+use Illuminate\Support\Facades\Validator as ValidatorFacade;
+use Illuminate\Validation\ValidationException;
+use Illuminate\Validation\Validator;
+
+class RecaptchaCustomValidationRuleTest extends TestCase
+{
+    /**
+     * @var Validator
+     */
+    private $validator;
+
+    /**
+     * @test
+     */
+    public function testValidationRuleValidatesResponse()
+    {
+        ReCaptcha::shouldReceive('validate')
+            ->once()
+            ->andReturn(true);
+
+        $this->assertTrue($this->validator->passes());
+    }
+
+    /**
+     * @test
+     */
+    public function testValidationRuleUsesTheDefaultErrorKey()
+    {
+        try {
+            $this->failValidation();
+        } catch (ValidationException $exception) {
+            $this->assertEquals(
+                'validation.' . ReCaptchaBuilder::DEFAULT_RECAPTCHA_RULE_NAME,
+                $exception->getMessage()
+            );
+        }
+    }
+
+    /**
+     * @test
+     */
+    public function testValidationRuleTranslatesTheErrorMessage()
+    {
+        Lang::addLines([
+            'validation.' . ReCaptchaBuilder::DEFAULT_RECAPTCHA_RULE_NAME => 'Translated recaptcha error'
+        ], $this->app->getLocale());
+
+        try {
+            $this->failValidation();
+        } catch (ValidationException $exception) {
+            $this->assertEquals(
+                'Translated recaptcha error',
+                $exception->getMessage()
+            );
+        }
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->validator = ValidatorFacade::make(
+            [ReCaptchaBuilder::DEFAULT_RECAPTCHA_FIELD_NAME => 'test'],
+            [ReCaptchaBuilder::DEFAULT_RECAPTCHA_FIELD_NAME => ReCaptchaBuilder::DEFAULT_RECAPTCHA_RULE_NAME]
+        );
+    }
+
+    /**
+     * @throws ValidationException
+     */
+    private function failValidation(): void
+    {
+        ReCaptcha::shouldReceive('validate')
+            ->once()
+            ->andReturn(false);
+
+        $this->validator->validate();
+
+        $this->fail('Expecting validation to throw an exception.');
+    }
+}


### PR DESCRIPTION
Hi,

As it's already discussed in [#63](https://github.com/biscolab/laravel-recaptcha/issues/63), using the `trans` helper in the boot method causes the translations to load, and any json translation file path added after will be never loaded.

While the workaround implemented in [5ceac2f](https://github.com/biscolab/laravel-recaptcha/commit/5ceac2f2ef56e374b09364d3fd01e7c02c0a745a) can solve the issue if i set the `"empty_message"` config value to true, in my opinion it is totally unnecessary. Laravel validation uses the same error key by default, the provided message is just a fallback message.

I've added some tests to verify the behaviour is the same without setting the fallback error message.
The documented way of customizing the error message remains the same: [https://github.com/biscolab/laravel-recaptcha?tab=readme-ov-file#customize-error-message](https://github.com/biscolab/laravel-recaptcha?tab=readme-ov-file#customize-error-message)
Nonetheless it can be a breaking change for ppl who modified the `"error_message_key"` in the recaptcha config and they didn't set the message in the validation.php lang file. I think the preferred way should be to set the translation instead.