### PR TITLE
CSP's nonce support for ReCaptchaBuilderV3

### DIFF
--- a/src/ReCaptchaBuilderV3.php
+++ b/src/ReCaptchaBuilderV3.php
@@ -70,7 +70,7 @@ class ReCaptchaBuilderV3 extends ReCaptchaBuilder
     public function htmlScriptTagJsApi(?array $configuration = []): string
     {
 
-        $nonce = $configuration['nonce'] ? implode('', ['nonce="', $configuration['nonce'], '"']) : '';
+        $nonce = isset($configuration['nonce']) ? implode('', ['nonce="', $configuration['nonce'], '"']) : '';
 
         if ($this->skip_by_ip) {
             return '';

--- a/src/ReCaptchaBuilderV3.php
+++ b/src/ReCaptchaBuilderV3.php
@@ -58,9 +58,9 @@ class ReCaptchaBuilderV3 extends ReCaptchaBuilder
             ]
         );
     }
-
+    
     /**
-     * Write script HTML tag in you HTML code
+     * Write script HTML tag in your HTML code
      * Insert before </head> tag
      *
      * @param array|null $configuration
@@ -70,17 +70,19 @@ class ReCaptchaBuilderV3 extends ReCaptchaBuilder
     public function htmlScriptTagJsApi(?array $configuration = []): string
     {
 
+        $nonce = $configuration['nonce'] ? implode('', ['nonce="', $configuration['nonce'], '"']) : '';
+
         if ($this->skip_by_ip) {
             return '';
         }
 
-        $html = "<script src=\"" . $this->api_js_url . "?render={$this->api_site_key}\"></script>";
+        $html = "<script {$nonce} src=\"" . $this->api_js_url . "?render={$this->api_site_key}\"></script>";
 
         $action = Arr::get($configuration, 'action', 'homepage');
 
         $js_custom_validation = Arr::get($configuration, 'custom_validation', '');
 
-        // Check if set custom_validation. That function will override default fetch validation function
+        // Check if set custom_validation. That function will override the default fetch validation function
         if ($js_custom_validation) {
 
             $validate_function = ($js_custom_validation) ? "{$js_custom_validation}(token);" : '';
@@ -107,7 +109,7 @@ class ReCaptchaBuilderV3 extends ReCaptchaBuilder
                 });";
         }
 
-        $html .= "<script>
+        $html .= "<script {$nonce}>
                     var csrfToken = document.head.querySelector('meta[name=\"csrf-token\"]');
                   grecaptcha.ready(function() {
                       grecaptcha.execute('{$this->api_site_key}', {action: '{$action}'}).then(function(token) {


### PR DESCRIPTION
Refactoring `htmlScriptTagJsApi()` method to provide basic support for [CSP's](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) `nonce` tag.

Leveraging the `$configuration` optional parameter to inject a `nonce` attribute in the inline Javascript tag.

The way to use this, on your Blade's (assuming you are using [https://github.com/spatie/laravel-csp](https://github.com/spatie/laravel-csp) or something else that generates the `nonce`): 

```
{{-- "csp_nonce()" in this case is provided by https://github.com/spatie/laravel-csp --}}
{!! \ReCaptcha::htmlScriptTagJsApi(['nonce' => csp_nonce()]) !!}
```